### PR TITLE
add logging on vault auth failure

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -244,6 +244,7 @@ impl VaultClient {
                 .map(String::from)
                 .ok_or_else(|| {
                     error!(self.logger, "No client auth token found");
+                    error!(self.logger, "{}", json);
                     Box::new(serde_json::Error::custom("No client auth token"))
                         as Box<dyn error::Error>
                 })


### PR DESCRIPTION
the datadog ecs service is failing to authenticate with vault despite it's task_role_arn being in the bound_iam_principal_arns. This PR serves to give me better logs around what's going on